### PR TITLE
Correct `ensureWorksheetOrder()` - missing element & sort func

### DIFF
--- a/static/helpers.js
+++ b/static/helpers.js
@@ -12,7 +12,8 @@
   }
 
   var worksheetOrder = {
-    dimension: 0,
+    sheetPr: -2,
+    dimension: -1,
     sheetViews: 1,
     sheetFormatPr: 2,
     cols: 3,
@@ -62,7 +63,10 @@
       var worksheet = data[key].worksheet
       var sortedWorksheet = {}
       Object.keys(worksheet).sort(function (a, b) {
-        return worksheetOrder[a] && worksheetOrder[b] && (worksheetOrder[a] > worksheetOrder[b])
+        if(!worksheetOrder[a]) return -1 // undefined in worksheetOrder goes at top of list
+        if(!worksheetOrder[b]) return 1
+        if(worksheetOrder[a] == worksheetOrder[b]) return 0
+        return worksheetOrder[a] > worksheetOrder[b] ? 1 : -1
       }).forEach(function (a) {
         sortedWorksheet[a] = worksheet[a]
       })


### PR DESCRIPTION
Fixes #6

With reference to the element ordering issues experienced on issue #6, I propose the following changes:
- Adjust the `sort()` function.
- Adjust the `dimension` index from `0` to `-1` to avoid the falsey zero.
- Add new `sheetPr` element at the head of the list.

Note that I have referred to this [reference](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.spreadsheet.worksheet.aspx?cs-save-lang=1&cs-lang=vb#code-snippet-1) but did not see a definite element ordering (I've not searched exhaustively). You will likely know this better than I.