### PR TITLE
fix "'" (apostrophe) escaping

### DIFF
--- a/src/jsonToXml.js
+++ b/src/jsonToXml.js
@@ -14,7 +14,7 @@ var entityMap = {
   '<': '&lt;',
   '>': '&gt;',
   '"': '&quot;',
-  "'": '&#39;',
+  "'": '&#x27;',
   '/': '&#x2F;',
   '=': '&#x3D;'
 }
@@ -24,7 +24,7 @@ var convertEntities = (str) => {
     return str
   }
 
-  return str.replace(/[<>&'"](?!(amp;|lt;|gt;|quot;|#39;|#x2F;|#x3D;))/g, function (s) {
+  return str.replace(/[<>&'"](?!(amp;|lt;|gt;|quot;|#x27;|#x2F;|#x3D;))/g, function (s) {
     console.log('escape ' + s)
     return entityMap[s]
   })

--- a/static/helpers.js
+++ b/static/helpers.js
@@ -169,7 +169,7 @@
     }
 
     // we escape &, it was probably bad idea and it should be done by handlebars instead
-    return xml.replace(/&(?!(amp;|lt;|gt;|quot;|#39;|#x2F;|#x3D;))/g, '&amp;')
+    return xml.replace(/&(?!(amp;|lt;|gt;|quot;|#x27;|#x2F;|#x3D;))/g, '&amp;')
   }
 
   function add (filePath, xmlPath) {

--- a/test/test.js
+++ b/test/test.js
@@ -312,6 +312,19 @@ describe('excel recipe with disabled add parsing', () => {
     })
   })
 
+  it('should escape \'', () => {
+    return reporter.render({
+      template: {
+        recipe: 'xlsx',
+        engine: 'handlebars',
+        content: fs.readFileSync(path.join(__dirname, 'content', 'add-row-with-foo-value.handlebars'), 'utf8')
+      },
+      data: { foo: 'JOHN\'S PET PRODUCTS' }
+    }).then((res) => {
+      xlsx.read(res.content).Sheets.Sheet1.A1.v.should.be.eql('JOHN\'S PET PRODUCTS')
+    })
+  })
+
   it('should escape entities', () => {
     return reporter.render({
       template: {


### PR DESCRIPTION
a fix for #29 

not sure if this is going to break anything or if the `&#39` numeric character for `'` ever worked, but it looks like all numeric characters that we need to use should be in hexadecimal, so i'm just changing `&#39;` to hex form -> `&#x27;`




